### PR TITLE
Init GTK after portal is registered

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,5 +22,6 @@ pub fn main() {
             std::process::exit(1);
         }
     };
+    ui.init_gtk();
     ui.run();
 }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -10,15 +10,8 @@ pub struct Ui {
     proxy: UiProxy,
 }
 
-fn init() {
-    gtk4::init().unwrap();
-    glib::set_prgname(Some("xdg-desktop-portal-gtk4"));
-}
-
 impl Ui {
     pub fn new() -> Self {
-        init();
-
         let main_loop = MainLoop::new(None, false);
         Self {
             proxy: UiProxy {
@@ -26,6 +19,11 @@ impl Ui {
             },
             main_loop,
         }
+    }
+
+    pub fn init_gtk(&self) {
+        gtk4::init().unwrap();
+        glib::set_prgname(Some("xdg-desktop-portal-gtk4"));
     }
 
     pub fn run(&self) {


### PR DESCRIPTION
Otherwise it is possible to hit a deadlock (25s timeout in practice) when xdg-desktop-portal spawns us, we run GTK init, which in turn queries settings via the portal, which waits on us registering the backend.